### PR TITLE
Update README Relative Links with Absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Contribution
 
 Use [Github issues](https://github.com/facebook/immutable-js/issues) for requests.
 
-We actively welcome pull requests, learn how to [contribute](./CONTRIBUTING.md).
+We actively welcome pull requests, learn how to [contribute](https://github.com/facebook/immutable-js/blob/master/CONTRIBUTING.md).
 
 
 Changelog
@@ -471,4 +471,4 @@ name. If you're looking for his unsupported package, see [this repository](https
 License
 -------
 
-`Immutable` is [BSD-licensed](./LICENSE). We also provide an additional [patent grant](./PATENTS).
+`Immutable` is [BSD-licensed](https://github.com/facebook/immutable-js/blob/master/LICENSE). We also provide an additional [patent grant](https://github.com/facebook/immutable-js/blob/master/PATENTS).


### PR DESCRIPTION
The relative links in README.md (i.e. ./LICENSE ./PATENTS, ./CONTRIBUTING) are working correctly in the Github repository, but are broken links on the Github Pages website. This commit replaces the relative links with absolute URLs.
